### PR TITLE
Add scholarship automation framework core modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Scholarship Automation Framework
+
+This repository provides a modular Python framework that models the core concepts of a scholarship application automation agent. The system combines intelligent discovery, adaptive navigation, transparent logging, and one-click submission review into a single orchestrated workflow.
+
+## Key Components
+
+- **Profile-Driven Automation** – `UserProfile` converts personal data into form-ready payloads so every application stays tailored to the applicant.
+- **Intelligent Discovery** – `ScholarshipDiscoveryEngine` explores the web with a driver abstraction, parses page content, and filters opportunities that match the profile.
+- **Adaptive Multi-Step Navigation** – `ApplicationNavigator` consumes live `PageSnapshot` data to identify actionable elements and step through multi-screen applications.
+- **Dynamic Form Interaction** – `FormInteractor` understands field semantics, fills them with profile data, and generates essays via `EssayGenerator`.
+- **Continuous Page Understanding** – `PageUnderstandingEngine` evaluates visibility, available actions, and form fields on every snapshot.
+- **One-Click Submission** – `SubmissionManager` tracks completed applications and finalizes them in one explicit call to `submit_all`.
+- **Full Transparency & Feedback** – `TransparencyLogger` records every action, making the automation auditable and easy to debug.
+- **Time-Agnostic Operation** – All browser actions are asynchronous, allowing drivers to wait for elements and slow pages without arbitrary sleeps.
+
+## Demonstration
+
+The `examples/demo.py` script stitches the modules together using an `InMemoryDriver`. Run it to see the event log generated while a profile is matched, an application is navigated, a form is filled (including an essay prompt), and the submission queue is finalized.
+
+```bash
+PYTHONPATH=src python -m examples.demo
+```
+
+## Extensibility
+
+The framework is deliberately driver-agnostic. To control a real browser, implement the protocols in `scholar_automation.discovery.PageDriver`, `scholar_automation.navigation.NavigableDriver`, and `scholar_automation.forms.FormDriver` using a tool such as Playwright or Selenium. Plug the implementation into the provided controllers to unlock full end-to-end automation.

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,0 +1,91 @@
+"""Demonstration of the scholarship automation framework using an in-memory driver."""
+from __future__ import annotations
+
+import asyncio
+
+from scholar_automation import (
+    ApplicationNavigator,
+    AutomationController,
+    FormInteractor,
+    PageUnderstandingEngine,
+    ScholarshipDiscoveryEngine,
+    SubmissionManager,
+    TransparencyLogger,
+    UserProfile,
+)
+from scholar_automation.drivers import FakePage, InMemoryDriver
+from scholar_automation.forms import EssayPrompt, FieldDescriptor, FormPlan
+from scholar_automation.page_understanding import PageElement
+
+
+async def main() -> None:
+    profile = UserProfile(
+        name="Ada Lovelace",
+        email="ada@example.com",
+        phone="555-0100",
+        gpa=3.9,
+        major="Computer Science",
+        school="Analytical Engine University",
+        metadata={"leadership": "Student Council"},
+    )
+
+    pages = {
+        "https://start": FakePage(
+            url="https://start",
+            text="STEM Scholars Program\nEligibility: Computer Science majors",
+            links=["https://application"],
+            elements=[
+                PageElement(selector="#apply", role="button", text="Apply"),
+            ],
+        ),
+        "https://application": FakePage(
+            url="https://application",
+            text="Scholarship Application Form",
+            links=[],
+            elements=[
+                PageElement(selector="#input-name", role="input", text="Name"),
+                PageElement(selector="#input-email", role="input", text="Email"),
+                PageElement(selector="#input-major", role="input", text="Major"),
+                PageElement(selector="#essay-purpose", role="textarea", text="Essay"),
+            ],
+        ),
+    }
+
+    driver = InMemoryDriver(pages=pages, start_url="https://start")
+    logger = TransparencyLogger()
+    understanding = PageUnderstandingEngine()
+    navigator = ApplicationNavigator(driver=driver, understanding=understanding, logger=logger)
+    discovery = ScholarshipDiscoveryEngine(driver=driver, logger=logger, seeds=["https://start"])
+    forms = FormInteractor(driver=driver, logger=logger)
+    submissions = SubmissionManager(logger=logger)
+    controller = AutomationController(
+        profile=profile,
+        discovery=discovery,
+        navigator=navigator,
+        form_interactor=forms,
+        submissions=submissions,
+        logger=logger,
+    )
+
+    # Override form plan building to include essay prompts for demo simplicity.
+    async def custom_plan() -> FormPlan:
+        snapshot = await navigator.snapshot()
+        fields = [
+            FieldDescriptor(selector="#input-name", label="name", field_type="text"),
+            FieldDescriptor(selector="#input-email", label="email", field_type="email"),
+            FieldDescriptor(selector="#input-major", label="major", field_type="text"),
+        ]
+        essays = [EssayPrompt(selector="#essay-purpose", prompt="Describe your goals.", word_limit=100)]
+        return FormPlan(fields=fields, essays=essays)
+
+    controller._build_form_plan = custom_plan  # type: ignore[assignment]
+
+    await controller.run()
+    await submissions.submit_all()
+
+    for event in logger.events:
+        print(f"[{event.timestamp:%H:%M:%S}] {event.message} {event.context}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -14,7 +14,6 @@ from scholar_automation import (
     UserProfile,
 )
 from scholar_automation.drivers import FakePage, InMemoryDriver
-from scholar_automation.forms import EssayPrompt, FieldDescriptor, FormPlan
 from scholar_automation.page_understanding import PageElement
 
 
@@ -33,7 +32,7 @@ async def main() -> None:
         "https://start": FakePage(
             url="https://start",
             text="STEM Scholars Program\nEligibility: Computer Science majors",
-            links=["https://application"],
+            links=[("#apply", "https://application")],
             elements=[
                 PageElement(selector="#apply", role="button", text="Apply"),
             ],
@@ -46,7 +45,7 @@ async def main() -> None:
                 PageElement(selector="#input-name", role="input", text="Name"),
                 PageElement(selector="#input-email", role="input", text="Email"),
                 PageElement(selector="#input-major", role="input", text="Major"),
-                PageElement(selector="#essay-purpose", role="textarea", text="Essay"),
+                PageElement(selector="#essay-purpose", role="textarea", text="Essay prompt: Describe your goals."),
             ],
         ),
     }
@@ -66,19 +65,6 @@ async def main() -> None:
         submissions=submissions,
         logger=logger,
     )
-
-    # Override form plan building to include essay prompts for demo simplicity.
-    async def custom_plan() -> FormPlan:
-        snapshot = await navigator.snapshot()
-        fields = [
-            FieldDescriptor(selector="#input-name", label="name", field_type="text"),
-            FieldDescriptor(selector="#input-email", label="email", field_type="email"),
-            FieldDescriptor(selector="#input-major", label="major", field_type="text"),
-        ]
-        essays = [EssayPrompt(selector="#essay-purpose", prompt="Describe your goals.", word_limit=100)]
-        return FormPlan(fields=fields, essays=essays)
-
-    controller._build_form_plan = custom_plan  # type: ignore[assignment]
 
     await controller.run()
     await submissions.submit_all()

--- a/src/scholar_automation/__init__.py
+++ b/src/scholar_automation/__init__.py
@@ -1,0 +1,22 @@
+"""Scholarship application automation framework."""
+
+from .profiles import UserProfile
+from .discovery import ScholarshipDiscoveryEngine, Opportunity
+from .navigation import ApplicationNavigator
+from .forms import FormInteractor
+from .page_understanding import PageUnderstandingEngine
+from .submission import SubmissionManager
+from .transparency import TransparencyLogger
+from .controller import AutomationController
+
+__all__ = [
+    "AutomationController",
+    "UserProfile",
+    "ScholarshipDiscoveryEngine",
+    "Opportunity",
+    "ApplicationNavigator",
+    "FormInteractor",
+    "PageUnderstandingEngine",
+    "SubmissionManager",
+    "TransparencyLogger",
+]

--- a/src/scholar_automation/controller.py
+++ b/src/scholar_automation/controller.py
@@ -1,0 +1,72 @@
+"""High-level orchestration for the scholarship automation workflow."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .discovery import Opportunity, ScholarshipDiscoveryEngine
+from .forms import EssayPrompt, FieldDescriptor, FormInteractor, FormPlan
+from .navigation import ApplicationNavigator
+from .profiles import UserProfile
+from .submission import SubmissionCandidate, SubmissionManager
+from .transparency import TransparencyLogger
+
+
+@dataclass
+class AutomationConfig:
+    seeds: Iterable[str]
+    max_depth: int = 2
+    max_results: int = 10
+
+
+class AutomationController:
+    """Coordinates discovery, navigation, form filling, and submission."""
+
+    def __init__(
+        self,
+        profile: UserProfile,
+        discovery: ScholarshipDiscoveryEngine,
+        navigator: ApplicationNavigator,
+        form_interactor: FormInteractor,
+        submissions: SubmissionManager,
+        logger: TransparencyLogger,
+    ) -> None:
+        self._profile = profile
+        self._discovery = discovery
+        self._navigator = navigator
+        self._forms = form_interactor
+        self._submissions = submissions
+        self._logger = logger
+
+    async def run(self) -> List[SubmissionCandidate]:
+        opportunities = await self._discovery.discover(self._profile)
+        await self._logger.log("Discovery completed", count=len(opportunities))
+        for opportunity in opportunities:
+            await self._process_opportunity(opportunity)
+        return self._submissions.dashboard.submitted
+
+    async def _process_opportunity(self, opportunity: Opportunity) -> None:
+        await self._logger.log("Processing opportunity", title=opportunity.title)
+        decisions = await self._navigator.run_until_blocked()
+        await self._logger.log("Navigation decisions", count=len(decisions))
+        plan = await self._build_form_plan()
+        filled = await self._forms.execute_plan(plan, self._profile)
+        candidate = SubmissionCandidate(
+            opportunity_title=opportunity.title,
+            application_url=opportunity.url,
+            filled_fields=filled,
+        )
+        await self._submissions.add_candidate(candidate)
+
+    async def _build_form_plan(self) -> FormPlan:
+        snapshot = await self._navigator.snapshot()
+        understanding_state = self._navigator.understanding.analyze(snapshot)
+        fields = [
+            FieldDescriptor(selector=selector, label=selector.split("-")[-1], field_type="")
+            for selector in understanding_state.form_fields
+        ]
+        essays = [
+            EssayPrompt(selector=prompt.selector, prompt=prompt.text or "", word_limit=None)
+            for prompt in understanding_state.essay_prompts
+        ]
+        return FormPlan(fields=fields, essays=essays)

--- a/src/scholar_automation/controller.py
+++ b/src/scholar_automation/controller.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 from typing import Iterable, List
 
 from .discovery import Opportunity, ScholarshipDiscoveryEngine
@@ -62,11 +63,34 @@ class AutomationController:
         snapshot = await self._navigator.snapshot()
         understanding_state = self._navigator.understanding.analyze(snapshot)
         fields = [
-            FieldDescriptor(selector=selector, label=selector.split("-")[-1], field_type="")
-            for selector in understanding_state.form_fields
+            FieldDescriptor(
+                selector=field.selector,
+                label=self._normalize_label(field.label),
+                field_type=field.field_type,
+            )
+            for field in understanding_state.form_fields
         ]
         essays = [
             EssayPrompt(selector=prompt.selector, prompt=prompt.text or "", word_limit=None)
             for prompt in understanding_state.essay_prompts
         ]
         return FormPlan(fields=fields, essays=essays)
+
+    @staticmethod
+    def _normalize_label(label: str) -> str:
+        sanitized = re.sub(r"[^a-z0-9]+", "_", label.lower()).strip("_")
+        mapping = {
+            "full_name": "name",
+            "first_name": "name",
+            "last_name": "name",
+            "email_address": "email",
+            "phone_number": "phone",
+            "telephone": "phone",
+            "mobile": "phone",
+            "grade_point_average": "gpa",
+            "field_of_study": "major",
+            "area_of_study": "major",
+            "university": "school",
+            "college": "school",
+        }
+        return mapping.get(sanitized, sanitized or label)

--- a/src/scholar_automation/discovery.py
+++ b/src/scholar_automation/discovery.py
@@ -1,0 +1,94 @@
+"""Scholarship discovery engine."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Iterable, List, Protocol
+
+from .profiles import UserProfile
+from .transparency import TransparencyLogger
+
+
+class PageDriver(Protocol):
+    """Protocol describing the subset of browser automation APIs we need."""
+
+    async def goto(self, url: str) -> None:
+        ...
+
+    async def extract_links(self) -> List[str]:
+        ...
+
+    async def extract_text(self) -> str:
+        ...
+
+
+@dataclass
+class Opportunity:
+    """Represents a scholarship opportunity discovered on the web."""
+
+    title: str
+    url: str
+    eligibility_tags: List[str]
+    estimated_time_minutes: int
+
+    def is_profile_match(self, profile: UserProfile) -> bool:
+        return profile.matches_tags(self.eligibility_tags)
+
+
+class ScholarshipDiscoveryEngine:
+    """Discovers scholarship opportunities starting from seed URLs."""
+
+    def __init__(
+        self,
+        driver: PageDriver,
+        logger: TransparencyLogger,
+        seeds: Iterable[str],
+        *,
+        max_depth: int = 2,
+        max_results: int = 25,
+    ) -> None:
+        self._driver = driver
+        self._logger = logger
+        self._seeds = tuple(seeds)
+        self._max_depth = max_depth
+        self._max_results = max_results
+
+    async def discover(self, profile: UserProfile) -> List[Opportunity]:
+        """Explore the web to find scholarship opportunities."""
+        discovered: List[Opportunity] = []
+        seen_urls = set()
+        queue = asyncio.Queue[tuple[str, int]]()
+        for seed in self._seeds:
+            await queue.put((seed, 0))
+
+        while not queue.empty() and len(discovered) < self._max_results:
+            url, depth = await queue.get()
+            if url in seen_urls or depth > self._max_depth:
+                continue
+            seen_urls.add(url)
+            await self._logger.log(f"Visiting {url}")
+            await self._driver.goto(url)
+            raw_text = await self._driver.extract_text()
+            opportunity = self._parse_opportunity(url, raw_text)
+            if opportunity and opportunity.is_profile_match(profile):
+                await self._logger.log(f"Discovered matching opportunity: {opportunity.title}")
+                discovered.append(opportunity)
+            for link in await self._driver.extract_links():
+                if link not in seen_urls:
+                    await queue.put((link, depth + 1))
+        return discovered
+
+    def _parse_opportunity(self, url: str, raw_text: str) -> Opportunity | None:
+        """Parse a scholarship opportunity from unstructured text."""
+        lines = [line.strip() for line in raw_text.splitlines() if line.strip()]
+        if not lines:
+            return None
+        title = lines[0]
+        tags = [
+            word.strip(".,:;!?")
+            for line in lines[1:5]
+            for word in line.split()
+            if word.isalpha() and len(word) > 2
+        ][:5]
+        estimated_time = max(10, min(60, len(lines) // 2 * 5))
+        return Opportunity(title=title, url=url, eligibility_tags=tags, estimated_time_minutes=estimated_time)

--- a/src/scholar_automation/drivers.py
+++ b/src/scholar_automation/drivers.py
@@ -1,0 +1,72 @@
+"""In-memory automation driver used for testing the automation pipeline."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .page_understanding import PageElement, PageSnapshot
+
+
+@dataclass
+class FakePage:
+    url: str
+    text: str
+    links: List[str]
+    elements: List[PageElement]
+    form_values: Dict[str, str] = field(default_factory=dict)
+
+
+class InMemoryDriver:
+    """Implements all driver protocols using an in-memory representation."""
+
+    def __init__(self, pages: Dict[str, FakePage], start_url: str) -> None:
+        if start_url not in pages:
+            raise ValueError("start_url must exist in pages")
+        self._pages = pages
+        self._current = pages[start_url]
+
+    async def goto(self, url: str) -> None:
+        await asyncio.sleep(0)
+        if url not in self._pages:
+            raise ValueError(f"Unknown URL: {url}")
+        self._current = self._pages[url]
+
+    async def extract_links(self) -> List[str]:
+        await asyncio.sleep(0)
+        return list(self._current.links)
+
+    async def extract_text(self) -> str:
+        await asyncio.sleep(0)
+        return self._current.text
+
+    async def current_snapshot(self) -> PageSnapshot:
+        await asyncio.sleep(0)
+        return PageSnapshot(url=self._current.url, elements=list(self._current.elements))
+
+    async def click(self, selector: str) -> None:
+        await asyncio.sleep(0)
+        for link in self._current.links:
+            if selector in link:
+                await self.goto(link)
+                return
+
+    async def fill(self, selector: str, value: str) -> None:
+        await asyncio.sleep(0)
+        self._current.form_values[selector] = value
+
+    async def select(self, selector: str, value: str) -> None:
+        await self.fill(selector, value)
+
+    async def check(self, selector: str, checked: bool = True) -> None:
+        await self.fill(selector, "true" if checked else "false")
+
+    async def focus(self, selector: str) -> None:
+        await asyncio.sleep(0)
+
+    async def evaluate_field_type(self, selector: str) -> str:
+        await asyncio.sleep(0)
+        for element in self._current.elements:
+            if element.selector == selector:
+                return element.role
+        return "text"

--- a/src/scholar_automation/drivers.py
+++ b/src/scholar_automation/drivers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from .page_understanding import PageElement, PageSnapshot
 
@@ -12,7 +12,7 @@ from .page_understanding import PageElement, PageSnapshot
 class FakePage:
     url: str
     text: str
-    links: List[str]
+    links: List[Tuple[str, str]]
     elements: List[PageElement]
     form_values: Dict[str, str] = field(default_factory=dict)
 
@@ -34,7 +34,7 @@ class InMemoryDriver:
 
     async def extract_links(self) -> List[str]:
         await asyncio.sleep(0)
-        return list(self._current.links)
+        return [target for _, target in self._current.links]
 
     async def extract_text(self) -> str:
         await asyncio.sleep(0)
@@ -46,9 +46,9 @@ class InMemoryDriver:
 
     async def click(self, selector: str) -> None:
         await asyncio.sleep(0)
-        for link in self._current.links:
-            if selector in link:
-                await self.goto(link)
+        for handle, target in self._current.links:
+            if selector == handle or selector == target:
+                await self.goto(target)
                 return
 
     async def fill(self, selector: str, value: str) -> None:

--- a/src/scholar_automation/forms.py
+++ b/src/scholar_automation/forms.py
@@ -30,7 +30,7 @@ class FormDriver(Protocol):
 class FieldDescriptor:
     selector: str
     label: str
-    field_type: str
+    field_type: str | None = None
 
 
 @dataclass

--- a/src/scholar_automation/forms.py
+++ b/src/scholar_automation/forms.py
@@ -1,0 +1,103 @@
+"""Dynamic form interaction utilities."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Dict, List, Protocol
+
+from .profiles import UserProfile
+from .transparency import TransparencyLogger
+
+
+class FormDriver(Protocol):
+    async def fill(self, selector: str, value: str) -> None:
+        ...
+
+    async def select(self, selector: str, value: str) -> None:
+        ...
+
+    async def check(self, selector: str, checked: bool = True) -> None:
+        ...
+
+    async def focus(self, selector: str) -> None:
+        ...
+
+    async def evaluate_field_type(self, selector: str) -> str:
+        ...
+
+
+@dataclass
+class FieldDescriptor:
+    selector: str
+    label: str
+    field_type: str
+
+
+@dataclass
+class EssayPrompt:
+    selector: str
+    prompt: str
+    word_limit: int | None = None
+
+
+@dataclass
+class FormPlan:
+    fields: List[FieldDescriptor]
+    essays: List[EssayPrompt]
+
+
+class EssayGenerator:
+    """Generates essay content from the profile."""
+
+    def __init__(self, profile: UserProfile) -> None:
+        self._profile = profile
+
+    def generate(self, prompt: EssayPrompt) -> str:
+        payload = self._profile.as_form_payload()
+        base = (
+            f"My name is {self._profile.name} and I am pursuing {payload.get('major', 'my studies')} at "
+            f"{payload.get('school', 'my university')} with a GPA of {payload.get('gpa', 'N/A')}.")
+        reflection = f"This opportunity aligns with my passion for {payload.get('major', 'learning')} because {prompt.prompt[:120]}"
+        essay = f"{base} {reflection}"
+        if prompt.word_limit:
+            return " ".join(essay.split()[: prompt.word_limit])
+        return essay
+
+
+class FormInteractor:
+    """Coordinates the filling of dynamic forms."""
+
+    def __init__(self, driver: FormDriver, logger: TransparencyLogger) -> None:
+        self._driver = driver
+        self._logger = logger
+
+    async def execute_plan(self, plan: FormPlan, profile: UserProfile) -> Dict[str, str]:
+        results: Dict[str, str] = {}
+        payload = profile.as_form_payload()
+        essay_generator = EssayGenerator(profile)
+        for field in plan.fields:
+            value = payload.get(field.label.lower()) or payload.get(field.label)
+            if value is None:
+                continue
+            await self._apply_field(field, value)
+            results[field.selector] = str(value)
+        for essay in plan.essays:
+            content = essay_generator.generate(essay)
+            await self._driver.focus(essay.selector)
+            await self._driver.fill(essay.selector, content)
+            await self._logger.log("Essay generated", selector=essay.selector, preview=content[:80])
+            results[essay.selector] = content
+        return results
+
+    async def _apply_field(self, field: FieldDescriptor, value: str) -> None:
+        field_type = field.field_type or await self._driver.evaluate_field_type(field.selector)
+        await self._logger.log("Filling field", selector=field.selector, field_type=field_type, value=value)
+        if field_type in {"text", "textarea", "email", "number"}:
+            await self._driver.fill(field.selector, value)
+        elif field_type == "select":
+            await self._driver.select(field.selector, value)
+        elif field_type in {"checkbox", "radio"}:
+            await self._driver.check(field.selector, True)
+        else:  # fallback
+            await self._driver.fill(field.selector, value)
+        await asyncio.sleep(0)

--- a/src/scholar_automation/navigation.py
+++ b/src/scholar_automation/navigation.py
@@ -1,0 +1,59 @@
+"""Adaptive multi-step navigation logic."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Protocol
+
+from .page_understanding import PageUnderstandingEngine, PageSnapshot
+from .transparency import TransparencyLogger
+
+
+class NavigableDriver(Protocol):
+    async def click(self, selector: str) -> None:
+        ...
+
+    async def current_snapshot(self) -> PageSnapshot:
+        ...
+
+
+@dataclass
+class NavigationDecision:
+    action: str
+    selector: str
+    reason: str
+
+
+class ApplicationNavigator:
+    """Responsible for traversing complex multi-step application flows."""
+
+    def __init__(self, driver: NavigableDriver, understanding: PageUnderstandingEngine, logger: TransparencyLogger) -> None:
+        self._driver = driver
+        self._understanding = understanding
+        self._logger = logger
+
+    @property
+    def understanding(self) -> PageUnderstandingEngine:
+        return self._understanding
+
+    async def snapshot(self) -> PageSnapshot:
+        return await self._driver.current_snapshot()
+
+    async def advance(self) -> NavigationDecision | None:
+        """Advance the application to the next step if possible."""
+        snapshot = await self._driver.current_snapshot()
+        state = self._understanding.analyze(snapshot)
+        for action in state.available_actions:
+            await self._logger.log("Navigating", action=action.label)
+            await self._driver.click(action.selector)
+            return NavigationDecision(action="click", selector=action.selector, reason=action.label)
+        await self._logger.log("Navigation paused", reason="No actionable elements found")
+        return None
+
+    async def run_until_blocked(self, max_steps: int = 20) -> List[NavigationDecision]:
+        decisions: List[NavigationDecision] = []
+        for _ in range(max_steps):
+            decision = await self.advance()
+            if decision is None:
+                break
+            decisions.append(decision)
+        return decisions

--- a/src/scholar_automation/page_understanding.py
+++ b/src/scholar_automation/page_understanding.py
@@ -1,0 +1,54 @@
+"""Continuous page understanding and state modeling."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class PageElement:
+    selector: str
+    role: str
+    text: str
+    visible: bool = True
+
+
+@dataclass
+class PageAction:
+    selector: str
+    label: str
+
+
+@dataclass
+class PageSnapshot:
+    url: str
+    elements: List[PageElement]
+
+
+@dataclass
+class PageState:
+    snapshot: PageSnapshot
+    available_actions: List[PageAction] = field(default_factory=list)
+    form_fields: List[str] = field(default_factory=list)
+    essay_prompts: List[PageElement] = field(default_factory=list)
+
+
+class PageUnderstandingEngine:
+    """Derives actionable insights from raw page snapshots."""
+
+    def analyze(self, snapshot: PageSnapshot) -> PageState:
+        actions = [
+            PageAction(selector=element.selector, label=element.text)
+            for element in snapshot.elements
+            if element.visible and element.role in {"button", "link", "submit"} and element.text
+        ]
+        form_fields = [element.selector for element in snapshot.elements if element.role == "input" and element.visible]
+        essay_prompts = [
+            element
+            for element in snapshot.elements
+            if element.visible and element.role in {"textarea", "essay"} and "essay" in element.text.lower()
+        ]
+        return PageState(snapshot=snapshot, available_actions=actions, form_fields=form_fields, essay_prompts=essay_prompts)
+
+    def has_review_summary(self, snapshot: PageSnapshot) -> bool:
+        return any("review" in element.text.lower() for element in snapshot.elements if element.visible)

--- a/src/scholar_automation/page_understanding.py
+++ b/src/scholar_automation/page_understanding.py
@@ -29,8 +29,15 @@ class PageSnapshot:
 class PageState:
     snapshot: PageSnapshot
     available_actions: List[PageAction] = field(default_factory=list)
-    form_fields: List[str] = field(default_factory=list)
+    form_fields: List["FormField"] = field(default_factory=list)
     essay_prompts: List[PageElement] = field(default_factory=list)
+
+
+@dataclass
+class FormField:
+    selector: str
+    label: str
+    field_type: str
 
 
 class PageUnderstandingEngine:
@@ -42,7 +49,12 @@ class PageUnderstandingEngine:
             for element in snapshot.elements
             if element.visible and element.role in {"button", "link", "submit"} and element.text
         ]
-        form_fields = [element.selector for element in snapshot.elements if element.role == "input" and element.visible]
+        form_fields = [
+            FormField(selector=element.selector, label=element.text or element.selector, field_type=element.role)
+            for element in snapshot.elements
+            if element.role in {"input", "select", "checkbox", "radio", "textarea", "email", "number"}
+            and element.visible
+        ]
         essay_prompts = [
             element
             for element in snapshot.elements

--- a/src/scholar_automation/profiles.py
+++ b/src/scholar_automation/profiles.py
@@ -1,0 +1,48 @@
+"""Profile management for scholarship automation."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional
+
+
+@dataclass(slots=True)
+class UserProfile:
+    """Represents the user whose information powers automation."""
+
+    name: str
+    email: str
+    phone: Optional[str]
+    gpa: Optional[float]
+    major: Optional[str]
+    school: Optional[str]
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def as_form_payload(self) -> Dict[str, str]:
+        """Return a flattened mapping that can be used to fill generic forms."""
+        payload: Dict[str, str] = {
+            "name": self.name,
+            "email": self.email,
+        }
+        if self.phone:
+            payload["phone"] = self.phone
+        if self.gpa is not None:
+            payload["gpa"] = f"{self.gpa:.2f}"
+        if self.major:
+            payload["major"] = self.major
+        if self.school:
+            payload["school"] = self.school
+        payload.update(self.metadata)
+        return payload
+
+    def matches_tags(self, tags: Iterable[str]) -> bool:
+        """Return True when the profile matches the provided eligibility tags."""
+        normalized_profile = {key.lower(): value.lower() for key, value in self.metadata.items()}
+        normalized_profile.update({
+            "major": (self.major or "").lower(),
+            "school": (self.school or "").lower(),
+        })
+        for tag in tags:
+            expected = tag.lower()
+            if expected and expected not in normalized_profile.values():
+                return False
+        return True

--- a/src/scholar_automation/profiles.py
+++ b/src/scholar_automation/profiles.py
@@ -31,18 +31,24 @@ class UserProfile:
             payload["major"] = self.major
         if self.school:
             payload["school"] = self.school
-        payload.update(self.metadata)
+        payload.update({key: str(value) for key, value in self.metadata.items() if value is not None})
         return payload
 
     def matches_tags(self, tags: Iterable[str]) -> bool:
         """Return True when the profile matches the provided eligibility tags."""
-        normalized_profile = {key.lower(): value.lower() for key, value in self.metadata.items()}
-        normalized_profile.update({
-            "major": (self.major or "").lower(),
-            "school": (self.school or "").lower(),
-        })
+        values = [value.lower() for value in self.metadata.values()]
+        if self.major:
+            values.append(self.major.lower())
+        if self.school:
+            values.append(self.school.lower())
+        token_set = {
+            token
+            for value in values
+            for token in value.replace("/", " ").replace("-", " ").split()
+            if token
+        }
         for tag in tags:
-            expected = tag.lower()
-            if expected and expected not in normalized_profile.values():
+            expected = tag.lower().strip()
+            if expected and expected not in token_set and all(expected not in value for value in values):
                 return False
         return True

--- a/src/scholar_automation/submission.py
+++ b/src/scholar_automation/submission.py
@@ -1,0 +1,43 @@
+"""One-click submission and review management."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .transparency import TransparencyLogger
+
+
+@dataclass
+class SubmissionCandidate:
+    opportunity_title: str
+    application_url: str
+    filled_fields: Dict[str, str]
+
+
+@dataclass
+class SubmissionDashboard:
+    candidates: List[SubmissionCandidate] = field(default_factory=list)
+    submitted: List[SubmissionCandidate] = field(default_factory=list)
+
+
+class SubmissionManager:
+    """Stores completed applications and handles explicit submissions."""
+
+    def __init__(self, logger: TransparencyLogger) -> None:
+        self._dashboard = SubmissionDashboard()
+        self._logger = logger
+
+    async def add_candidate(self, candidate: SubmissionCandidate) -> None:
+        self._dashboard.candidates.append(candidate)
+        await self._logger.log("Candidate ready for review", opportunity=candidate.opportunity_title)
+
+    async def submit_all(self) -> List[SubmissionCandidate]:
+        while self._dashboard.candidates:
+            candidate = self._dashboard.candidates.pop(0)
+            self._dashboard.submitted.append(candidate)
+            await self._logger.log("Submitted application", opportunity=candidate.opportunity_title)
+        return list(self._dashboard.submitted)
+
+    @property
+    def dashboard(self) -> SubmissionDashboard:
+        return self._dashboard

--- a/src/scholar_automation/transparency.py
+++ b/src/scholar_automation/transparency.py
@@ -1,0 +1,36 @@
+"""Transparency, logging, and feedback utilities."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List
+
+
+@dataclass
+class TransparencyEvent:
+    timestamp: datetime
+    message: str
+    context: dict[str, object] = field(default_factory=dict)
+
+
+class TransparencyLogger:
+    """Collects events describing automation actions."""
+
+    def __init__(self) -> None:
+        self._events: List[TransparencyEvent] = []
+        self._queue: asyncio.Queue[TransparencyEvent] = asyncio.Queue()
+
+    async def log(self, message: str, **context: object) -> None:
+        event = TransparencyEvent(timestamp=datetime.utcnow(), message=message, context=context)
+        self._events.append(event)
+        await self._queue.put(event)
+
+    async def stream(self):  # pragma: no cover - convenience generator
+        while True:
+            event = await self._queue.get()
+            yield event
+
+    @property
+    def events(self) -> List[TransparencyEvent]:
+        return list(self._events)


### PR DESCRIPTION
## Summary
- implement a modular scholarship automation framework covering discovery, navigation, form filling, and submissions
- add an in-memory driver and demo script to exercise the end-to-end workflow
- document the architecture and usage instructions in a new README

## Testing
- PYTHONPATH=src python -m examples.demo

------
https://chatgpt.com/codex/tasks/task_e_68e1ef7386c8832fbd2f591f772b74a7